### PR TITLE
Update to Typescript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     "style-loader": "0.16.1",
     "thread-loader": "1.1.2",
     "ts-loader": "4.0.1",
-    "tslib": "~1.10.0",
+    "tslib": "~1.11.0",
     "tslint": "5.9.1",
     "typedoc": "~0.16.9",
-    "typescript": "~3.8.1-rc",
+    "typescript": "~3.8.2",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
     "webpack-dev-server": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "extract-loader": "0.1.0",
     "ifdef-loader": "2.0.0",
     "file-loader": "0.11.1",
-    "fork-ts-checker-webpack-plugin": "0.4.1",
+    "fork-ts-checker-webpack-plugin": "0.4.4",
     "html-loader": "0.4.5",
     "imports-loader": "0.7.1",
     "jasmine": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     "style-loader": "0.16.1",
     "thread-loader": "1.1.2",
     "ts-loader": "4.0.1",
-    "tslib": "1.9.0",
+    "tslib": "~1.10.0",
     "tslint": "5.9.1",
-    "typedoc": "0.11.1",
-    "typescript": "2.8.1",
+    "typedoc": "~0.16.9",
+    "typescript": "~3.8.1-rc",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
     "webpack-dev-server": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "docker_packages.txt"
   ],
   "dependencies": {
-    "phovea_security_flask": "github:phovea/phovea_security_flask#typescript_3.8",
+    "phovea_security_flask": "github:phovea/phovea_security_flask#develop",
     "docker-names": "1.0.3"
   },
   "main": "build/phovea_security_store_generated.js",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "docker_packages.txt"
   ],
   "dependencies": {
-    "phovea_security_flask": "github:phovea/phovea_security_flask#develop",
+    "phovea_security_flask": "github:phovea/phovea_security_flask#typescript_3.8",
     "docker-names": "1.0.3"
   },
   "main": "build/phovea_security_store_generated.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "jsx": "react",
     "experimentalDecorators": true,
+    "downlevelIteration": true, // required as long as target is `es5`
     "lib": [
       "dom",
       "es2015",


### PR DESCRIPTION
Closes #8 

### Summary
* update to typescript `v3.8` and typedoc `v0.16.9`
* switch branches in _package.json_
* update `tslib`
* set `downlevelIteration": true` in _tsconfig.json_ 