### PR TITLE
Decode login credentials if binary

### DIFF
--- a/phovea_security_store_generated/store.py
+++ b/phovea_security_store_generated/store.py
@@ -88,6 +88,11 @@ INSERT INTO user(username, password, salt, roles, creation_date, last_login_date
     return next((u for u in self._users if u.id == id), None)
 
   def load_from_key(self, api_key):
+    try:
+      api_key = api_key.decode()  # Convert to string if bytes-like
+    except (UnicodeDecodeError, AttributeError):
+      pass
+
     parts = api_key.split(':')
     if len(parts) != 2:
       return None


### PR DESCRIPTION
I noticed that passing credentials via Basic Authentifcation is no longer working. We are using this for health checks.

The Server fails with an internal error as the api_key here can no longer be split: https://github.com/datavisyn/phovea_security_store_generated/blob/master/phovea_security_store_generated/store.py#L91

```
api_1          | Traceback (most recent call last):
api_1          |   File "/usr/local/lib/python3.7/site-packages/gevent/pywsgi.py", line 976, in handle_one_response
api_1          |     self.run_application()
api_1          |   File "/usr/local/lib/python3.7/site-packages/geventwebsocket/handler.py", line 87, in run_application
api_1          |     return super(WebSocketHandler, self).run_application()
api_1          |   File "/usr/local/lib/python3.7/site-packages/gevent/pywsgi.py", line 923, in run_application
api_1          |     self.result = self.application(self.environ, self.start_response)
api_1          |   File "/usr/local/lib/python3.7/site-packages/werkzeug/middleware/proxy_fix.py", line 169, in __call__
api_1          |     return self.app(environ, start_response)
api_1          |   File "/phovea/phovea_server/phovea_server/dispatcher.py", line 62, in __call__
api_1          |     return app(environ, start_response)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
api_1          |     return self.wsgi_app(environ, start_response)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
api_1          |     response = self.handle_exception(e)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception
api_1          |     reraise(exc_type, exc_value, tb)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
api_1          |     raise value
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
api_1          |     response = self.full_dispatch_request()
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
api_1          |     rv = self.handle_user_exception(e)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
api_1          |     reraise(exc_type, exc_value, tb)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
api_1          |     raise value
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
api_1          |     rv = self.dispatch_request()
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
api_1          |     return self.view_functions[rule.endpoint](**req.view_args)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask_login/utils.py", line 270, in decorated_view
api_1          |     elif not current_user.is_authenticated:
api_1          |   File "/usr/local/lib/python3.7/site-packages/werkzeug/local.py", line 347, in __getattr__
api_1          |     return getattr(self._get_current_object(), name)
api_1          |   File "/usr/local/lib/python3.7/site-packages/werkzeug/local.py", line 306, in _get_current_object
api_1          |     return self.__local()
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask_login/utils.py", line 26, in <lambda>
api_1          |     current_user = LocalProxy(lambda: _get_user())
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask_login/utils.py", line 346, in _get_user
api_1          |     current_app.login_manager._load_user()
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask_login/login_manager.py", line 331, in _load_user
api_1          |     user = self._load_user_from_request(request)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask_login/login_manager.py", line 390, in _load_user_from_request
api_1          |     user = self._request_callback(request)
api_1          |   File "/phovea/phovea_security_flask/phovea_security_flask/flask_login_impl.py", line 159, in _load_user_from_request
api_1          |     user = self._load_user_from_key(api_key)
api_1          |   File "/phovea/phovea_security_flask/phovea_security_flask/flask_login_impl.py", line 138, in _load_user_from_key
api_1          |     u = store.load_from_key(api_key)
api_1          |   File "/phovea/phovea_security_store_generated/phovea_security_store_generated/store.py", line 91, in load_from_key
api_1          |     parts = api_key.split(':')
api_1          | TypeError: a bytes-like object is required, not 'str'
api_1          | 2020-11-18T18:36:26Z {'REMOTE_ADDR': '172.18.0.1', 'REMOTE_PORT': '43608', 'HTTP_HOST': 'localhost:8080', (hidden keys: 23)} failed with TypeError
api_1          |
api_1          | Traceback (most recent call last):
api_1          |   File "/usr/local/lib/python3.7/site-packages/gevent/pywsgi.py", line 976, in handle_one_response
api_1          |     self.run_application()
api_1          |   File "/usr/local/lib/python3.7/site-packages/geventwebsocket/handler.py", line 87, in run_application
api_1          |     return super(WebSocketHandler, self).run_application()
api_1          |   File "/usr/local/lib/python3.7/site-packages/gevent/pywsgi.py", line 923, in run_application
api_1          |     self.result = self.application(self.environ, self.start_response)
api_1          |   File "/usr/local/lib/python3.7/site-packages/werkzeug/middleware/proxy_fix.py", line 169, in __call__
api_1          |     return self.app(environ, start_response)
api_1          |   File "/phovea/phovea_server/phovea_server/dispatcher.py", line 62, in __call__
api_1          |     return app(environ, start_response)
api_1          |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
api_1          |     return self.wsgi_app(environ, start_response)
```

Looks like that worked in Python 2 but not in Python 3: https://stackoverflow.com/questions/33054527/