### PR TITLE
Pin markupsafe==2.0.1 to avoid soft_unicode import error 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pydng==1.1.2
+# Pin markupsafe to avoid ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.7/site-packages/markupsafe/__init__.py) 
+markupsafe==2.0.1
 -e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server
 -e git+https://github.com/datavisyn/tdp_core.git@develop#egg=tdp_core


### PR DESCRIPTION
Fixes build errors like `ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/circleci/venv/lib/python3.7/site-packages/markupsafe/__init__.py)`. 

See https://github.com/phovea/phovea_server/issues/154 for details. 